### PR TITLE
Bug correction & Windows start file

### DIFF
--- a/Chubuntu_1.2/Chubuntu_1.1_win.bat
+++ b/Chubuntu_1.2/Chubuntu_1.1_win.bat
@@ -1,0 +1,3 @@
+cd ./sources
+python accueuil.py
+exit

--- a/Chubuntu_1.2/sources/accueuil.py
+++ b/Chubuntu_1.2/sources/accueuil.py
@@ -77,7 +77,7 @@ window = Tk()
 window.bind("<Control_L>"+"q",destroy)
 
 window.title("zapaovi")
-window.attributes('-zoomed', True)
+window.attributes('-fullscreen', True)
 window.config(background='#2f3034')
 window.minsize(480, 360)
 

--- a/Chubuntu_1.2/sources/accueuil.py
+++ b/Chubuntu_1.2/sources/accueuil.py
@@ -77,7 +77,7 @@ window = Tk()
 window.bind("<Control_L>"+"q",destroy)
 
 window.title("zapaovi")
-window.attributes('-fullscreen', True)
+window.attributes('-zoomed', True)
 window.config(background='#2f3034')
 window.minsize(480, 360)
 


### PR DESCRIPTION
Un fichier de démarrage pour Windows a été ajouté.
Un bug survenu lors du lancement a été corrigé, l'attribut `-zoomed` a été remplacer par `-fullscreen`.
A vérifier si le résultat fonctionne bien sur les autres OS.